### PR TITLE
Support non_null(list_of()) and :id

### DIFF
--- a/lib/absinthe_constraints/directive.ex
+++ b/lib/absinthe_constraints/directive.ex
@@ -26,7 +26,7 @@ defmodule AbsintheConstraints.Directive do
 
   @string_args [:min_length, :max_length, :format, :pattern]
   @number_args [:min, :max]
-  @list_args [:min_items, :max_items]
+  @list_args [:min_items, :max_items] ++ @string_args
 
   directive :constraints do
     on([:argument_definition, :field_definition])

--- a/lib/absinthe_constraints/validator.ex
+++ b/lib/absinthe_constraints/validator.ex
@@ -21,6 +21,10 @@ defmodule AbsintheConstraints.Validator do
       else: []
   end
 
+  def handle_constraint({:min_length, min_length}, value) when is_list(value) do
+    value |> Enum.map(&handle_constraint({:min_length, min_length}, &1.data)) |> List.flatten()
+  end
+
   def handle_constraint({:min_length, min_length}, value) do
     if String.length(value) < min_length,
       do: ["must be at least #{min_length} characters in length"],
@@ -33,10 +37,18 @@ defmodule AbsintheConstraints.Validator do
       else: []
   end
 
+  def handle_constraint({:max_length, max_length}, value) when is_list(value) do
+    value |> Enum.map(&handle_constraint({:max_length, max_length}, &1.data)) |> List.flatten()
+  end
+
   def handle_constraint({:max_length, max_length}, value) do
     if String.length(value) > max_length,
       do: ["must be no more than #{max_length} characters in length"],
       else: []
+  end
+
+  def handle_constraint({:format, "uuid"}, value) when is_list(value) do
+    value |> Enum.map(&handle_constraint({:format, "uuid"}, &1.data)) |> List.flatten()
   end
 
   def handle_constraint({:format, "uuid"}, value) do
@@ -48,10 +60,18 @@ defmodule AbsintheConstraints.Validator do
 
   @email_regex ~r/^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/
 
+  def handle_constraint({:format, "email"}, value) when is_list(value) do
+    value |> Enum.map(&handle_constraint({:format, "email"}, &1.data)) |> List.flatten()
+  end
+
   def handle_constraint({:format, "email"}, value) do
     if String.match?(value, @email_regex),
       do: [],
       else: ["must be a valid email address"]
+  end
+
+  def handle_constraint({:pattern, regex}, value) when is_list(value) do
+    value |> Enum.map(&handle_constraint({:pattern, regex}, &1.data)) |> List.flatten()
   end
 
   def handle_constraint({:pattern, regex}, value) do

--- a/test/integration/api_test.exs
+++ b/test/integration/api_test.exs
@@ -23,6 +23,10 @@ defmodule AbsintheConstraints.Integration.APITest do
             directives: [constraints: [pattern: "^[A-Z][0-9a-z]*$"]]
           )
 
+          arg(:ids, non_null(list_of(non_null(:id))),
+            directives: [constraints: [format: "uuid"]]
+          )
+
           resolve(fn _, _ -> {:ok, "test_result"} end)
         end
       end
@@ -47,7 +51,9 @@ defmodule AbsintheConstraints.Integration.APITest do
 
     test "should return success on valid query arguments" do
       assert {:ok, %{data: %{"test" => "test_result"}}} ==
-               TestSchema.run_query("{ test(list: [1, 3], number: 5, regexField: \"A123aa\") }")
+               TestSchema.run_query(
+                 "{ test(list: [1, 3], number: 5, regexField: \"A123aa\", ids: [\"6C20BCCA-9396-452B-99AB-F2C168CA7A58\", \"6C20BCCA-9396-452B-99AB-F2C168CA7A58\"]) }"
+               )
     end
 
     test "should return errors on invalid query arguments" do
@@ -65,10 +71,13 @@ defmodule AbsintheConstraints.Integration.APITest do
                   %{
                     message: "\"regexField\" must match regular expression `^[A-Z][0-9a-z]*$`",
                     locations: [%{line: 1, column: 30}]
-                  }
+                  },
+                  %{message: "\"ids\" must be a valid UUID", locations: [%{line: 1, column: 53}]}
                 ]
               }} ==
-               TestSchema.run_query("{ test(list: [1], number: 1, regexField: \"invalid\") }")
+               TestSchema.run_query(
+                 "{ test(list: [1], number: 1, regexField: \"invalid\", ids: [\"6C20BCCA-9396-452B-99AB-F2C168CA7A58\", \"INVALID\"])}"
+               )
     end
 
     test "should return errors on valid mutation arguments" do


### PR DESCRIPTION
Adds support for the request in #6 

- Adds support for the id type. 
- Adds support for the curious case of non_null(list_of()) raising the following error
```
Invalid constraints for field/arg `id` of type `%Absinthe.Blueprint.TypeReference.NonNull{of_type: %Absinthe.Blueprint.TypeReference.List{of_type: :string, errors: []}, errors: []}`: [:format]


    (absinthe_constraints 0.2.0) lib/absinthe_constraints/directive.ex:72: AbsintheConstraints.Directive.handle_invalid_args/2
    (absinthe_constraints 0.2.0) lib/absinthe_constraints/directive.ex:61: AbsintheConstraints.Directive.do_expand/3
    (elixir 1.16.1) lib/enum.ex:2528: Enum."-reduce/3-lists^foldl/2-0-"/3
    (absinthe 1.7.6) lib/absinthe/blueprint/transform.ex:16: anonymous fn/3 in Absinthe.Blueprint.Transform.prewalk/2
    (absinthe 1.7.6) lib/absinthe/blueprint/transform.ex:117: Absinthe.Blueprint.Transform.walk/4
    (elixir 1.16.1) lib/enum.ex:1826: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
    (absinthe 1.7.6) lib/absinthe/blueprint/transform.ex:147: anonymous fn/4 in Absinthe.Blueprint.Transform.walk_children/5
    (elixir 1.16.1) lib/enum.ex:2528: Enum."-reduce/3-lists^foldl/2-0-"/3
    (absinthe 1.7.6) lib/absinthe/blueprint/transform.ex:122: Absinthe.Blueprint.Transform.walk/4
    (elixir 1.16.1) lib/enum.ex:1826: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
    (elixir 1.16.1) lib/enum.ex:1826: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
    (absinthe 1.7.6) lib/absinthe/blueprint/transform.ex:147: anonymous fn/4 in Absinthe.Blueprint.Transform.walk_children/5
    (elixir 1.16.1) lib/enum.ex:2528: Enum."-reduce/3-lists^foldl/2-0-"/3
    (absinthe 1.7.6) lib/absinthe/blueprint/transform.ex:122: Absinthe.Blueprint.Transform.walk/4
    (elixir 1.16.1) lib/enum.ex:1826: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
    (elixir 1.16.1) lib/enum.ex:1826: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
    (absinthe 1.7.6) lib/absinthe/blueprint/transform.ex:147: anonymous fn/4 in Absinthe.Blueprint.Transform.walk_children/5
    (elixir 1.16.1) lib/enum.ex:2528: Enum."-reduce/3-lists^foldl/2-0-"/3
    (absinthe 1.7.6) lib/absinthe/blueprint/transform.ex:122: Absinthe.Blueprint.Transform.walk/4
    (elixir 1.16.1) lib/enum.ex:1826: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
```


Looking forward to your reviews and more tests scenarios to consider. 

Thanks